### PR TITLE
Use node 18 for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     name: Build Docker Image
     strategy:
       matrix:
-        base-image: [alpine3.16, bullseye, buster]
+        base-image: [alpine3.17, bullseye, buster]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -57,10 +57,10 @@ jobs:
               `${image_name}:${major}.${minor}.${patch}`,
             ]
             const tags = []
-            if (base_image === 'alpine3.16') {
+            if (base_image === 'alpine3.17') {
               tags.push(...version_tags.map(tag => `${tag}-alpine`))
-              tags.push(...version_tags.map(tag => `${tag}-alpine3.16`))
-              tags.push(`${image_name}:alpine`, `${image_name}:alpine3.16`)
+              tags.push(...version_tags.map(tag => `${tag}-alpine3.17`))
+              tags.push(`${image_name}:alpine`, `${image_name}:alpine3.17`)
               core.exportVariable('DOCKERFILE_NAME', 'docker/Dockerfile.alpine')
             } else if (base_image === 'bullseye') {
               tags.push(...version_tags.map(tag => `${tag}-${base_image}`))

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM node:19.3.0-alpine3.16 as base
+FROM node:18.12.1-alpine3.17 as base
 
 FROM base as builder
 


### PR DESCRIPTION
Node v19 has issue when building to `arm/v7`. The releases should stick to v18 until #215 is fixed