### PR TITLE
Remove docker image hash so Renovate can regenerate them

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM node:20.15.0-alpine3.20@sha256:0ccc08fadfe696f2959f59404ce0d90461c834a7465c4a563c62c0fef4089885 as base
+FROM node:20.15.0-alpine3.20 as base
 
 FROM base as builder
 

--- a/docker/Dockerfile.bookworm
+++ b/docker/Dockerfile.bookworm
@@ -1,4 +1,4 @@
-FROM node:20.15.0-bookworm@sha256:4db67aec2ba104897ac9af929efdbc0c95a026cb986ed83cea29fb3bb46b0506 as base
+FROM node:20.15.0-bookworm as base
 
 FROM base as builder
 

--- a/docker/Dockerfile.bullseye
+++ b/docker/Dockerfile.bullseye
@@ -1,4 +1,4 @@
-FROM node:20.15.0-bullseye@sha256:d13caa9c51c77c40dce433dc6ab9db3af3664c052417e684a291cad0af04f904 as base
+FROM node:20.15.0-bullseye as base
 
 FROM base as builder
 

--- a/docker/Dockerfile.buster
+++ b/docker/Dockerfile.buster
@@ -1,4 +1,4 @@
-FROM node:20.15.0-buster@sha256:479103df06b40b90f189461b6f824a62906683e26a32c77d7c3e2d855a0e3e9f as base
+FROM node:20.15.0-buster as base
 
 FROM base as builder
 


### PR DESCRIPTION
The current sha256 are wrong after Renovate updates